### PR TITLE
Prevent Javadoc from ending first sentence after "e.g."

### DIFF
--- a/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathLogicalBranchesTest.java
+++ b/drools-test-coverage/test-suite/src/test/java/org/drools/testcoverage/functional/oopath/OOPathLogicalBranchesTest.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Tests usage of OOPath expressions resulting in multiple conditional branches (e.g. OR operator).
+ * Tests usage of OOPath expressions resulting in multiple conditional branches (e.g. the OR operator).
  */
 public class OOPathLogicalBranchesTest {
 


### PR DESCRIPTION
This little trick will prevent Javadoc from ending the first sentence after "e.g.". The first sentence is ended when a full stop is followed by a whitespace UNLESS the next word starts with a lowercase letter.